### PR TITLE
Physics Fixed Timestep fix

### DIFF
--- a/rfsim/sources/Simulator.cpp
+++ b/rfsim/sources/Simulator.cpp
@@ -99,25 +99,12 @@ namespace rfsim {
             // 3) Tick algorithm control (if required)
             // 4) Update physics settings (motors power) (if required)
 
-            mPhysicsServer->AccumulateDeltaTime(dt);
 
-            while (mPhysicsServer->TryGameStep())
-            {
-                algo->TickGame(mPhysicsServer->GetFixedDt(), t, *game);
+            auto onFixedStep = [&algo, t, &game] (float fixedDt) {
+                algo->TickGame(fixedDt, t, *game);
+            };
 
-                for (int i = 0; i < game->teamSize; i++) {
-                    auto id = game->physicsGameInitInfo.robotsTeamA[i].id;
-                    const auto &wv = game->robotWheelVelocitiesA[i];
-                    mPhysicsServer->UpdateWheelVelocities(id, wv.x, wv.y);
-                }
-
-                for (int i = 0; i < game->teamSize; i++) {
-                    auto id = game->physicsGameInitInfo.robotsTeamB[i].id;
-                    const auto &wv = game->robotWheelVelocitiesB[i];
-                    mPhysicsServer->UpdateWheelVelocities(id, wv.x, wv.y);
-                }
-            }
-
+            mPhysicsServer->FrameStep(game, onFixedStep, dt, t);
             mPhysicsServer->GetCurrentGameState(game->physicsGameState);
 
             mGraphicsServer->BeginDraw(dt, game->physicsGameState);

--- a/rfsim/sources/gui/GuiSimulator.cpp
+++ b/rfsim/sources/gui/GuiSimulator.cpp
@@ -211,25 +211,26 @@ namespace rfsim {
                 if (gameState == GameState::Running) {
                     t += simDt;
 
-                    PhysicsGameState state;
-                    mPhysicsServer->GameStep(simDt);
-                    mPhysicsServer->GetCurrentGameState(state);
+                    mPhysicsServer->AccumulateDeltaTime(simDt);
 
-                    game->physicsGameState = state;
-                    algo->TickGame(simDt, t, *game);
+                    while (mPhysicsServer->TryGameStep()) {
+                        algo->TickGame(mPhysicsServer->GetFixedDt(), t, *game);
 
-                    for (int i = 0; i < game->teamSize; i++) {
-                        auto id = game->physicsGameInitInfo.robotsTeamA[i].id;
-                        const auto &wv = game->robotWheelVelocitiesA[i];
-                        mPhysicsServer->UpdateWheelVelocities(id, wv.x, wv.y);
-                    }
+                        for (int i = 0; i < game->teamSize; i++) {
+                            auto id = game->physicsGameInitInfo.robotsTeamA[i].id;
+                            const auto &wv = game->robotWheelVelocitiesA[i];
+                            mPhysicsServer->UpdateWheelVelocities(id, wv.x, wv.y);
+                        }
 
-                    for (int i = 0; i < game->teamSize; i++) {
-                        auto id = game->physicsGameInitInfo.robotsTeamB[i].id;
-                        const auto &wv = game->robotWheelVelocitiesB[i];
-                        mPhysicsServer->UpdateWheelVelocities(id, wv.x, wv.y);
+                        for (int i = 0; i < game->teamSize; i++) {
+                            auto id = game->physicsGameInitInfo.robotsTeamB[i].id;
+                            const auto &wv = game->robotWheelVelocitiesB[i];
+                            mPhysicsServer->UpdateWheelVelocities(id, wv.x, wv.y);
+                        }
                     }
                 }
+
+                mPhysicsServer->GetCurrentGameState(game->physicsGameState);
 
                 mPainter->FitToFramebufferArea();
 

--- a/rfsim/sources/gui/GuiSimulator.cpp
+++ b/rfsim/sources/gui/GuiSimulator.cpp
@@ -192,9 +192,7 @@ namespace rfsim {
 
                 t = 0.0f;
 
-                PhysicsGameState state;
-                mPhysicsServer->GetCurrentGameState(state);
-                game->physicsGameState = state;
+                mPhysicsServer->GetCurrentGameState(game->physicsGameState);
 
                 mState = State::InGame;
                 gameState = GameState::Paused;
@@ -211,23 +209,11 @@ namespace rfsim {
                 if (gameState == GameState::Running) {
                     t += simDt;
 
-                    mPhysicsServer->AccumulateDeltaTime(simDt);
+                    auto onFixedStep = [&algo, t, &game] (float fixedDt) {
+                        algo->TickGame(fixedDt, t, *game);
+                    };
 
-                    while (mPhysicsServer->TryGameStep()) {
-                        algo->TickGame(mPhysicsServer->GetFixedDt(), t, *game);
-
-                        for (int i = 0; i < game->teamSize; i++) {
-                            auto id = game->physicsGameInitInfo.robotsTeamA[i].id;
-                            const auto &wv = game->robotWheelVelocitiesA[i];
-                            mPhysicsServer->UpdateWheelVelocities(id, wv.x, wv.y);
-                        }
-
-                        for (int i = 0; i < game->teamSize; i++) {
-                            auto id = game->physicsGameInitInfo.robotsTeamB[i].id;
-                            const auto &wv = game->robotWheelVelocitiesB[i];
-                            mPhysicsServer->UpdateWheelVelocities(id, wv.x, wv.y);
-                        }
-                    }
+                    mPhysicsServer->FrameStep(game, onFixedStep, simDt, t);
                 }
 
                 mPhysicsServer->GetCurrentGameState(game->physicsGameState);

--- a/rfsim/sources/physics/PhysicsServer.hpp
+++ b/rfsim/sources/physics/PhysicsServer.hpp
@@ -41,7 +41,7 @@ namespace rfsim {
 
     class PhysicsServer {
     public:
-        PhysicsServer();
+        PhysicsServer(float fixedDt = 1.0f / 60.0f);
         ~PhysicsServer();
 
         PhysicsServer(const PhysicsServer &other) = delete;
@@ -51,7 +51,11 @@ namespace rfsim {
 
         void SetGameProperties(const PhysicsGameProperties& properties);
         void BeginGame(const PhysicsGameInitInfo& info);
-        void GameStep(float dt);
+       
+        void AccumulateDeltaTime(float dt);
+        float GetFixedDt() const;
+        bool TryGameStep();
+
         void UpdateWheelVelocities(int robotId, float leftWheelVelocity, float rightWheelVelocity);
         void GetCurrentGameState(PhysicsGameState& state) const;
         void EndGame();
@@ -73,7 +77,8 @@ namespace rfsim {
         static float AngleToGameCoords(float angle);
 
     private:
-        float dtAccumulated;
+        float mFixedDt;
+        float mDtAccumulated;
 
         std::shared_ptr<b2World> mWorld;
         std::shared_ptr<PhysicsContactListener> mContactListener;

--- a/rfsim/sources/physics/PhysicsServer.hpp
+++ b/rfsim/sources/physics/PhysicsServer.hpp
@@ -25,12 +25,14 @@
 #ifndef RFSIM_PHYSICSSERVER_HPP
 #define RFSIM_PHYSICSSERVER_HPP
 
+#include <functional>
 #include <map>
 #include <memory>
 
 #include <physics/PhysicsGameProperties.hpp>
 #include <physics/PhysicsGameInitInfo.hpp>
 #include <physics/PhysicsGameState.hpp>
+#include <logic/Game.hpp>
 
 class b2World;
 class b2Body;
@@ -51,16 +53,18 @@ namespace rfsim {
 
         void SetGameProperties(const PhysicsGameProperties& properties);
         void BeginGame(const PhysicsGameInitInfo& info);
-       
-        void AccumulateDeltaTime(float dt);
-        float GetFixedDt() const;
-        bool TryGameStep();
-
+        void FrameStep(const std::shared_ptr<const Game> &game, 
+                       std::function<void(float fixedDt)> onFixedStep,
+                       float dt, float t);
         void UpdateWheelVelocities(int robotId, float leftWheelVelocity, float rightWheelVelocity);
         void GetCurrentGameState(PhysicsGameState& state) const;
         void EndGame();
 
     private:
+        void AccumulateDeltaTime(float dt);
+        float GetFixedDt() const;
+        bool TryFixedStep();
+
         void SetFieldFriction(b2Body *target, float maxForceMult = 1.0f, float maxTorqueMult = 1.0f);
 
         bool IsRoomBounds(b2Body *body) const;


### PR DESCRIPTION
Fixed inconsistency in delta time for physics (`fixedDt`) and drawing (`dt`) engines. 
Algorithms are now using `fixedDt` as they provide velocity info only for physics engine.