### PR TITLE
Physics Fixed Timestep fix for master

### DIFF
--- a/rfsim/sources/Simulator.cpp
+++ b/rfsim/sources/Simulator.cpp
@@ -97,6 +97,8 @@ namespace rfsim {
 
         mPhysicsServer->SetGameProperties(game->physicsGameProperties);
         mPhysicsServer->BeginGame(game->physicsGameInitInfo);
+        mPhysicsServer->GetCurrentGameState(game->physicsGameState);
+
         mGraphicsServer->BeginGame(game->graphicsSceneSettings);
 
         algo->BeginGame(*game);
@@ -121,7 +123,6 @@ namespace rfsim {
             };
 
             mPhysicsServer->FrameStep(game, onFixedStep, dt);
-            mPhysicsServer->GetCurrentGameState(game->physicsGameState);
 
             mGraphicsServer->BeginDraw(dt, game->physicsGameState);
             mGraphicsServer->DrawStaticObjects();

--- a/rfsim/sources/Simulator.cpp
+++ b/rfsim/sources/Simulator.cpp
@@ -112,12 +112,15 @@ namespace rfsim {
             // 3) Tick algorithm control (if required)
             // 4) Update physics settings (motors power) (if required)
 
-
-            auto onFixedStep = [&algo, t, &game] (float fixedDt) {
+            // Return true if must continue physics sim step
+            auto onFixedStep = [&] (float fixedDt) {
                 algo->TickGame(fixedDt, t, *game);
+                t += fixedDt;
+
+                return true;
             };
 
-            mPhysicsServer->FrameStep(game, onFixedStep, dt, t);
+            mPhysicsServer->FrameStep(game, onFixedStep, dt);
             mPhysicsServer->GetCurrentGameState(game->physicsGameState);
 
             mGraphicsServer->BeginDraw(dt, game->physicsGameState);

--- a/rfsim/sources/Simulator.cpp
+++ b/rfsim/sources/Simulator.cpp
@@ -112,11 +112,28 @@ namespace rfsim {
             // 3) Tick algorithm control (if required)
             // 4) Update physics settings (motors power) (if required)
 
-            PhysicsGameState state;
-            mPhysicsServer->GameStep(dt);
-            mPhysicsServer->GetCurrentGameState(state);
+            mPhysicsServer->AccumulateDeltaTime(dt);
 
-            mGraphicsServer->BeginDraw(dt, state);
+            while (mPhysicsServer->TryGameStep())
+            {
+                algo->TickGame(mPhysicsServer->GetFixedDt(), t, *game);
+
+                for (int i = 0; i < game->teamSize; i++) {
+                    auto id = game->physicsGameInitInfo.robotsTeamA[i].id;
+                    const auto &wv = game->robotWheelVelocitiesA[i];
+                    mPhysicsServer->UpdateWheelVelocities(id, wv.x, wv.y);
+                }
+
+                for (int i = 0; i < game->teamSize; i++) {
+                    auto id = game->physicsGameInitInfo.robotsTeamB[i].id;
+                    const auto &wv = game->robotWheelVelocitiesB[i];
+                    mPhysicsServer->UpdateWheelVelocities(id, wv.x, wv.y);
+                }
+            }
+
+            mPhysicsServer->GetCurrentGameState(game->physicsGameState);
+
+            mGraphicsServer->BeginDraw(dt, game->physicsGameState);
             mGraphicsServer->DrawStaticObjects();
             mGraphicsServer->DrawDynamicObjects();
             mGraphicsServer->DrawAuxInfo();
@@ -126,21 +143,6 @@ namespace rfsim {
             mWindowManager->UpdateEvents();
             mWindowManager->SwapBuffers();
             mPainter->FitToFramebufferArea();
-
-            game->physicsGameState = state;
-            algo->TickGame(dt, t, *game);
-
-            for (int i = 0; i < game->teamSize; i++) {
-                auto id = game->physicsGameInitInfo.robotsTeamA[i].id;
-                const auto &wv = game->robotWheelVelocitiesA[i];
-                mPhysicsServer->UpdateWheelVelocities(id, wv.x, wv.y);
-            }
-
-            for (int i = 0; i < game->teamSize; i++) {
-                auto id = game->physicsGameInitInfo.robotsTeamB[i].id;
-                const auto &wv = game->robotWheelVelocitiesB[i];
-                mPhysicsServer->UpdateWheelVelocities(id, wv.x, wv.y);
-            }
 
             frameCount++;
             t += dt;

--- a/rfsim/sources/Simulator.cpp
+++ b/rfsim/sources/Simulator.cpp
@@ -112,25 +112,12 @@ namespace rfsim {
             // 3) Tick algorithm control (if required)
             // 4) Update physics settings (motors power) (if required)
 
-            mPhysicsServer->AccumulateDeltaTime(dt);
 
-            while (mPhysicsServer->TryGameStep())
-            {
-                algo->TickGame(mPhysicsServer->GetFixedDt(), t, *game);
+            auto onFixedStep = [&algo, t, &game] (float fixedDt) {
+                algo->TickGame(fixedDt, t, *game);
+            };
 
-                for (int i = 0; i < game->teamSize; i++) {
-                    auto id = game->physicsGameInitInfo.robotsTeamA[i].id;
-                    const auto &wv = game->robotWheelVelocitiesA[i];
-                    mPhysicsServer->UpdateWheelVelocities(id, wv.x, wv.y);
-                }
-
-                for (int i = 0; i < game->teamSize; i++) {
-                    auto id = game->physicsGameInitInfo.robotsTeamB[i].id;
-                    const auto &wv = game->robotWheelVelocitiesB[i];
-                    mPhysicsServer->UpdateWheelVelocities(id, wv.x, wv.y);
-                }
-            }
-
+            mPhysicsServer->FrameStep(game, onFixedStep, dt, t);
             mPhysicsServer->GetCurrentGameState(game->physicsGameState);
 
             mGraphicsServer->BeginDraw(dt, game->physicsGameState);

--- a/rfsim/sources/gui/GuiSimulator.cpp
+++ b/rfsim/sources/gui/GuiSimulator.cpp
@@ -187,13 +187,13 @@ namespace rfsim {
                     ImGui::NewLine();
 
                     ImGui::Text(" - 3. Select game rules (leave empty for no rules)");
-                    ImGui::BeginListBox("Rules");
+                    if (ImGui::BeginListBox("Rules")) {
+                        for (int i = 0; i < rules.size(); i++) {
+                             ImGui::Selectable(rules[i].data(), &selectedRules[i].v);
+                        }
 
-                    for (int i = 0; i < rules.size(); i++) {
-                        ImGui::Selectable(rules[i].data(), &selectedRules[i].v);
+                        ImGui::EndListBox();
                     }
-
-                    ImGui::EndListBox();
                     ImGui::NewLine();
 
                     ImGui::PushStyleColor(ImGuiCol_Button, mStyle.greenColor);

--- a/rfsim/sources/gui/GuiSimulator.cpp
+++ b/rfsim/sources/gui/GuiSimulator.cpp
@@ -244,23 +244,21 @@ namespace rfsim {
 
                     // Return true if must continue physics sim step
                     auto onFixedStep = [&] (float fixedDt) {
-                        algo->TickGame(fixedDt, t, *game);
                         auto res = rule->Process(t, fixedDt, *game);
-
-                        t += fixedDt;
 
                         if (res == GameMessage::Finish) {
                             gameState = GameState::Finished;
                             return false;
                         }
 
+                        algo->TickGame(fixedDt, t, *game);
+                        t += fixedDt;
+
                         return true;
                     };
 
                     mPhysicsServer->FrameStep(game, onFixedStep, simDt);
                 }
-
-                mPhysicsServer->GetCurrentGameState(game->physicsGameState);
 
                 mPainter->FitToFramebufferArea();
 

--- a/rfsim/sources/physics/PhysicsServer.cpp
+++ b/rfsim/sources/physics/PhysicsServer.cpp
@@ -289,7 +289,7 @@ namespace rfsim {
         }
     }
 
-    void PhysicsServer::FrameStep(const std::shared_ptr<const Game> &game, const std::function<bool(float)> &onFixedStep, float dt) {
+    void PhysicsServer::FrameStep(const std::shared_ptr<Game> &game, const std::function<bool(float)> &onFixedStep, float dt) {
         assert(game->physicsGameInitInfo.robotsTeamA.size() >= game->teamSize);
         assert(game->physicsGameInitInfo.robotsTeamB.size() >= game->teamSize);
         assert(game->robotWheelVelocitiesA.size() >= game->teamSize);
@@ -309,7 +309,7 @@ namespace rfsim {
 
         AccumulateDeltaTime(dt);
 
-        while (TryFixedStep() && onFixedStep(GetFixedDt()))
+        while (TryFixedStep() && UpdateState(game) && onFixedStep(GetFixedDt()))
         {
             for (int t = 0; t < teamCount; t++) {
                 const auto &rs = *(pRs[t]);
@@ -388,6 +388,11 @@ namespace rfsim {
 
         mDtAccumulated -= mFixedDt;
 
+        return true;
+    }
+
+    bool PhysicsServer::UpdateState(const std::shared_ptr<Game> &game) {
+        GetCurrentGameState(game->physicsGameState);
         return true;
     }
 

--- a/rfsim/sources/physics/PhysicsServer.cpp
+++ b/rfsim/sources/physics/PhysicsServer.cpp
@@ -375,7 +375,7 @@ namespace rfsim {
         // or no distance between wheels
         if (std::abs(Vl - Vr) < eps || l < eps) {
             b2Vec2 dir = { cos_theta, sin_theta };
-            float v = (std::abs(Vr) + std::abs(Vl)) / 2.0f;
+            float v = (Vr + Vl) / 2.0f;
 
             robot->SetLinearVelocity(v * dir);
             robot->SetAngularVelocity(0);
@@ -387,12 +387,12 @@ namespace rfsim {
             b2Vec2 ICC = { x - R * sin_theta, y + R * cos_theta };
 
             // move ICC to origin
-            float x_n = x - ICC.x;
-            float y_n = y - ICC.y;
+            const float x_i = x - ICC.x;
+            const float y_i = y - ICC.y;
 
             // rotate by w in ICC space
-            x_n = cosf(w * dt) * x_n - sinf(w * dt) * y_n;
-            y_n = sinf(w * dt) * x_n + cosf(w * dt) * y_n;
+            float x_n = cosf(w * dt) * x_i - sinf(w * dt) * y_i;
+            float y_n = sinf(w * dt) * x_i + cosf(w * dt) * y_i;
 
             // move from ICC space to world space
             x_n += ICC.x;

--- a/rfsim/sources/physics/PhysicsServer.cpp
+++ b/rfsim/sources/physics/PhysicsServer.cpp
@@ -353,7 +353,7 @@ namespace rfsim {
     }
 
     void PhysicsServer::AccumulateDeltaTime(float dt) {
-        return mDtAccumulated += dt;
+        mDtAccumulated += dt;
     }
 
     float PhysicsServer::GetFixedDt() const

--- a/rfsim/sources/physics/PhysicsServer.hpp
+++ b/rfsim/sources/physics/PhysicsServer.hpp
@@ -41,7 +41,7 @@ namespace rfsim {
 
     class PhysicsServer {
     public:
-        PhysicsServer();
+        PhysicsServer(float fixedDt = 1.0f / 60.0f);
         ~PhysicsServer();
 
         PhysicsServer(const PhysicsServer &other) = delete;
@@ -51,7 +51,11 @@ namespace rfsim {
 
         void SetGameProperties(const PhysicsGameProperties& properties);
         void BeginGame(const PhysicsGameInitInfo& info);
-        void GameStep(float dt);
+       
+        void AccumulateDeltaTime(float dt);
+        float GetFixedDt() const;
+        bool TryGameStep();
+
         void UpdateWheelVelocities(int robotId, float leftWheelVelocity, float rightWheelVelocity);
         void GetCurrentGameState(PhysicsGameState& state) const;
         void EndGame();
@@ -73,7 +77,8 @@ namespace rfsim {
         static float AngleToGameCoords(float angle);
 
     private:
-        float dtAccumulated;
+        float mFixedDt;
+        float mDtAccumulated;
 
         std::shared_ptr<b2World> mWorld;
         std::shared_ptr<PhysicsContactListener> mContactListener;

--- a/rfsim/sources/physics/PhysicsServer.hpp
+++ b/rfsim/sources/physics/PhysicsServer.hpp
@@ -53,7 +53,7 @@ namespace rfsim {
 
         void SetGameProperties(const PhysicsGameProperties& properties);
         void BeginGame(const PhysicsGameInitInfo& info);
-        void FrameStep(const std::shared_ptr<const Game> &game, const std::function<bool(float)> &onFixedStep, float dt);
+        void FrameStep(const std::shared_ptr<Game> &game, const std::function<bool(float)> &onFixedStep, float dt);
         void UpdateWheelVelocities(int robotId, float leftWheelVelocity, float rightWheelVelocity);
         void GetCurrentGameState(PhysicsGameState& state) const;
         void EndGame();
@@ -62,6 +62,7 @@ namespace rfsim {
         void AccumulateDeltaTime(float dt);
         float GetFixedDt() const;
         bool TryFixedStep();
+        bool UpdateState(const std::shared_ptr<Game> &game);
 
         void SetFieldFriction(b2Body *target, float maxForceMult = 1.0f, float maxTorqueMult = 1.0f);
 

--- a/rfsim/sources/physics/PhysicsServer.hpp
+++ b/rfsim/sources/physics/PhysicsServer.hpp
@@ -43,7 +43,7 @@ namespace rfsim {
 
     class PhysicsServer {
     public:
-        PhysicsServer(float fixedDt = 1.0f / 60.0f);
+        explicit PhysicsServer(float fixedDt = 1.0f / 60.0f);
         ~PhysicsServer();
 
         PhysicsServer(const PhysicsServer &other) = delete;
@@ -53,9 +53,7 @@ namespace rfsim {
 
         void SetGameProperties(const PhysicsGameProperties& properties);
         void BeginGame(const PhysicsGameInitInfo& info);
-        void FrameStep(const std::shared_ptr<const Game> &game, 
-                       std::function<void(float fixedDt)> onFixedStep,
-                       float dt, float t);
+        void FrameStep(const std::shared_ptr<const Game> &game, const std::function<bool(float)> &onFixedStep, float dt);
         void UpdateWheelVelocities(int robotId, float leftWheelVelocity, float rightWheelVelocity);
         void GetCurrentGameState(PhysicsGameState& state) const;
         void EndGame();

--- a/rfsim/sources/physics/PhysicsServer.hpp
+++ b/rfsim/sources/physics/PhysicsServer.hpp
@@ -25,12 +25,14 @@
 #ifndef RFSIM_PHYSICSSERVER_HPP
 #define RFSIM_PHYSICSSERVER_HPP
 
+#include <functional>
 #include <map>
 #include <memory>
 
 #include <physics/PhysicsGameProperties.hpp>
 #include <physics/PhysicsGameInitInfo.hpp>
 #include <physics/PhysicsGameState.hpp>
+#include <logic/Game.hpp>
 
 class b2World;
 class b2Body;
@@ -51,16 +53,18 @@ namespace rfsim {
 
         void SetGameProperties(const PhysicsGameProperties& properties);
         void BeginGame(const PhysicsGameInitInfo& info);
-       
-        void AccumulateDeltaTime(float dt);
-        float GetFixedDt() const;
-        bool TryGameStep();
-
+        void FrameStep(const std::shared_ptr<const Game> &game, 
+                       std::function<void(float fixedDt)> onFixedStep,
+                       float dt, float t);
         void UpdateWheelVelocities(int robotId, float leftWheelVelocity, float rightWheelVelocity);
         void GetCurrentGameState(PhysicsGameState& state) const;
         void EndGame();
 
     private:
+        void AccumulateDeltaTime(float dt);
+        float GetFixedDt() const;
+        bool TryFixedStep();
+
         void SetFieldFriction(b2Body *target, float maxForceMult = 1.0f, float maxTorqueMult = 1.0f);
 
         bool IsRoomBounds(b2Body *body) const;


### PR DESCRIPTION
Fixed inconsistency in delta time for physics (`fixedDt`) and drawing (`dt`) engines. 
Algorithms are now using `fixedDt` as they provide velocity info only for physics engine.

Note: this branch is cherry-picked version of `physics-dt`, for merging in `master`.